### PR TITLE
feat: set blue as primary theme color

### DIFF
--- a/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/App.kt
+++ b/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/App.kt
@@ -2,7 +2,7 @@ package fr.nicopico.petitboutiste
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
+import fr.nicopico.petitboutiste.ui.PetitBoutisteTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,7 +33,7 @@ fun App() {
     val selectedTabIndex = tabs.indexOfFirst { it.id == selectedTabId }.takeIf { it >= 0 } ?: 0
     val selectedTab = tabs.getOrNull(selectedTabIndex) ?: tabs.first()
 
-    MaterialTheme {
+    PetitBoutisteTheme {
         Column(modifier = Modifier.fillMaxSize()) {
             // Tab bar for switching between tabs
             TabBar(

--- a/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/ui/PetitBoutisteTheme.kt
+++ b/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/ui/PetitBoutisteTheme.kt
@@ -1,0 +1,20 @@
+package fr.nicopico.petitboutiste.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val PetitBoutisteColorScheme = lightColorScheme(
+    primary = Color(0xFF1F3D91),
+    primaryContainer = Color(0xFFDEE4F8)
+)
+
+@Composable
+fun PetitBoutisteTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = PetitBoutisteColorScheme,
+        content = content
+    )
+}
+

--- a/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/ui/PetitBoutisteTheme.kt
+++ b/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/ui/PetitBoutisteTheme.kt
@@ -7,7 +7,9 @@ import androidx.compose.ui.graphics.Color
 
 private val PetitBoutisteColorScheme = lightColorScheme(
     primary = Color(0xFF1F3D91),
-    primaryContainer = Color(0xFFDEE4F8)
+    primaryContainer = Color(0xFFDEE4F8),
+    surfaceVariant = Color(0xFFE2F4FB),
+    onSurfaceVariant = Color(0xFF1C1B1F)
 )
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/ui/TabBar.kt
+++ b/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/ui/TabBar.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
@@ -50,7 +51,9 @@ fun TabBar(
 
     Surface(
         modifier = modifier.fillMaxWidth(),
-        shadowElevation = 4.dp
+        shadowElevation = 4.dp,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -60,12 +63,16 @@ fun TabBar(
             TabRow(
                 selectedTabIndex = tabs.indexOfFirst { it.id == selectedTabId }.takeIf { it >= 0 } ?: 0,
                 modifier = Modifier.weight(1f),
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant
             ) {
                 tabs.forEach { tab ->
                     Tab(
                         selected = tab.id == selectedTabId,
                         onClick = { onTabSelected(tab.id) },
                         modifier = Modifier.height(48.dp),
+                        selectedContentColor = MaterialTheme.colorScheme.primary,
+                        unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                         text = {
                             Row(
                                 verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/ui/components/HexDisplay.kt
+++ b/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/ui/components/HexDisplay.kt
@@ -88,7 +88,7 @@ fun HexDisplay(
                                 .clickable { onByteItemClicked(item) }
                                 .let {
                                     if (item is ByteItem.Group) {
-                                        it.border(1.dp, Color.Blue)
+                                        it.border(1.dp, MaterialTheme.colorScheme.primary)
                                     } else it
                                 }
                                 .let {
@@ -123,7 +123,7 @@ fun HexDisplay(
                                 style = TextStyle(
                                     fontFamily = FontFamily.Monospace,
                                     fontSize = 8.sp,
-                                    color = Color.Blue
+                                    color = MaterialTheme.colorScheme.primary
                                 ),
                                 softWrap = false,
                                 maxLines = 1,

--- a/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/ui/infra/preview/WrapForPreview.kt
+++ b/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/ui/infra/preview/WrapForPreview.kt
@@ -1,13 +1,13 @@
 package fr.nicopico.petitboutiste.ui.infra.preview
 
-import androidx.compose.material3.MaterialTheme
+import fr.nicopico.petitboutiste.ui.PetitBoutisteTheme
 import androidx.compose.runtime.Composable
 
 @Composable
 fun WrapForPreview(
     content: @Composable () -> Unit
 ) {
-    MaterialTheme {
+    PetitBoutisteTheme {
         content()
     }
 }


### PR DESCRIPTION
## Summary
- define PetitBoutisteTheme with #1F3D91 as the primary color
- apply theme in App and preview wrapper
- align HexDisplay to use theme primary color

## Testing
- `./gradlew build` *(fails: Could not get resource 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.2.0/kotlin-stdlib-2.2.0.pom'. Received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68944432d564832fbf1d54594fa23c01