### PR TITLE
chore: improve layout performance

### DIFF
--- a/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/ui/theme/PBThemeTypography.kt
+++ b/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/ui/theme/PBThemeTypography.kt
@@ -25,15 +25,25 @@ private class PBThemeTypographyImpl : PBThemeTypography {
 
     override val title : TextStyle
         @Composable
-        get() = JewelTheme.createDefaultTextStyle(
-            fontWeight = FontWeight.Bold,
-            fontSize = JewelTheme.defaultTextStyle.fontSize * 1.1,
-        )
+        get() {
+            val defaultFontSize = JewelTheme.defaultTextStyle.fontSize
+            return remember(this, defaultFontSize) {
+                JewelTheme.createDefaultTextStyle(
+                    fontWeight = FontWeight.Bold,
+                    fontSize = defaultFontSize * 1.1,
+                )
+            }
+        }
 
     override val data: TextStyle
         @Composable
-        get() = JewelTheme.createDefaultTextStyle(
-            fontFamily = FontFamily.Monospace,
-            fontSize = JewelTheme.defaultTextStyle.fontSize * 1.2,
-        )
+        get() {
+            val defaultFontSize = JewelTheme.defaultTextStyle.fontSize
+            return remember(this, defaultFontSize) {
+                JewelTheme.createDefaultTextStyle(
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = defaultFontSize * 1.2,
+                )
+            }
+        }
 }


### PR DESCRIPTION
`JewelTheme.createDefaultTextStyle()` is slow and not cached by default. 
Using it in a Composable can have a big impact on performances

**Before**
<img width="715" height="160" alt="image" src="https://github.com/user-attachments/assets/87609d3a-757c-4ea8-abf2-10da6581024c" />

**After**
<img width="822" height="248" alt="image" src="https://github.com/user-attachments/assets/81175d44-9f39-465d-b153-990eeedf7a45" />
