### PR TITLE
feat: create definition by mouse selection

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
         // "Class 'fr.nicopico.petitboutiste.scripting.PetitBoutisteApi' was compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler"
         // (see `ScriptHost` class)
         freeCompilerArgs.addAll(
+            "-Xexplicit-backing-fields", // Workaround for IDEA "syntax error"
             "-Xcontext-parameters",
         )
 

--- a/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/models/definition/ByteItemExt.kt
+++ b/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/models/definition/ByteItemExt.kt
@@ -39,8 +39,8 @@ fun ByteItem.toByteArray(): ByteArray {
 }
 
 /**
- * Return `true` if [other] is *entirely* contained into this [ByteItem],
- * meaning *all* the bytes of `other` are also in the `ByteItem
+ * Returns `true` if [other] is entirely contained in this [ByteItem],
+ * meaning *all* the bytes of `other` are also in the `ByteItem`
  */
 operator fun ByteItem.contains(other: ByteItem): Boolean = other.firstIndex >= firstIndex
     && other.lastIndex <= lastIndex

--- a/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/models/definition/ByteItemExt.kt
+++ b/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/models/definition/ByteItemExt.kt
@@ -37,3 +37,10 @@ fun ByteItem.toByteArray(): ByteArray {
 
     return data
 }
+
+/**
+ * Return `true` if [other] is *entirely* contained into this [ByteItem],
+ * meaning *all* the bytes of `other` are also in the `ByteItem
+ */
+operator fun ByteItem.contains(other: ByteItem): Boolean = other.firstIndex >= firstIndex
+    && other.lastIndex <= lastIndex

--- a/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/models/definition/ByteItemListExt.kt
+++ b/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/models/definition/ByteItemListExt.kt
@@ -47,6 +47,12 @@ fun List<ByteItem>.toByteGroup(
     if (any { it !is SingleByte }) return null
     if (isEmpty()) return null
 
+    val isConsecutive = zipWithNext()
+        .all { (previous, current) ->
+            current.firstIndex == previous.firstIndex + 1
+        }
+    if (!isConsecutive) return null
+
     return ByteGroup(
         bytes = map { (it as SingleByte).value},
         definition = ByteGroupDefinition(

--- a/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/models/definition/ByteItemListExt.kt
+++ b/composeApp/src/commonMain/kotlin/fr/nicopico/petitboutiste/models/definition/ByteItemListExt.kt
@@ -6,7 +6,9 @@
 
 package fr.nicopico.petitboutiste.models.definition
 
+import fr.nicopico.petitboutiste.models.representation.DEFAULT_REPRESENTATION
 import fr.nicopico.petitboutiste.models.representation.RenderResult
+import fr.nicopico.petitboutiste.models.representation.Representation
 import fr.nicopico.petitboutiste.models.representation.isOff
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -37,4 +39,19 @@ suspend fun List<ByteItem>.toJsonData(): String {
             }
         }
     return prettyJson.encodeToString(payloadEntries.toMap())
+}
+
+fun List<ByteItem>.toByteGroup(
+    representation: Representation = DEFAULT_REPRESENTATION,
+): ByteGroup? {
+    if (any { it !is SingleByte }) return null
+    if (isEmpty()) return null
+
+    return ByteGroup(
+        bytes = map { (it as SingleByte).value},
+        definition = ByteGroupDefinition(
+            indexes = first().firstIndex..last().lastIndex,
+            representation = representation,
+        )
+    )
 }

--- a/composeApp/src/commonTest/kotlin/fr/nicopico/petitboutiste/models/definition/ByteItemListExtTest.kt
+++ b/composeApp/src/commonTest/kotlin/fr/nicopico/petitboutiste/models/definition/ByteItemListExtTest.kt
@@ -1,0 +1,52 @@
+package fr.nicopico.petitboutiste.models.definition
+
+import fr.nicopico.petitboutiste.models.representation.DEFAULT_REPRESENTATION
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ByteItemListExtTest {
+
+    @Test
+    fun `toByteGroup returns null for empty list`() {
+        val list = emptyList<ByteItem>()
+        assertNull(list.toByteGroup())
+    }
+
+    @Test
+    fun `toByteGroup returns null if contains non-SingleByte item`() {
+        // Need to create a ByteGroup to put into the list
+        val singleByte = SingleByte(0, "AA")
+        val byteGroup = ByteGroup(
+            bytes = listOf("BB"),
+            definition = ByteGroupDefinition(indexes = 1..1, representation = DEFAULT_REPRESENTATION)
+        )
+        val list = listOf(singleByte, byteGroup)
+        assertNull(list.toByteGroup())
+    }
+
+    @Test
+    fun `toByteGroup returns null for non-consecutive indices`() {
+        val list = listOf(
+            SingleByte(0, "AA"),
+            SingleByte(2, "BB") // Indices 0 and 2 are not consecutive (should be 0 and 1)
+        )
+        assertNull(list.toByteGroup())
+    }
+
+    @Test
+    fun `toByteGroup returns ByteGroup for consecutive SingleByte items`() {
+        val list = listOf(
+            SingleByte(0, "AA"),
+            SingleByte(1, "BB"),
+            SingleByte(2, "CC")
+        )
+        val byteGroup = list.toByteGroup()
+
+        // Assertions
+        assert(byteGroup != null)
+        assertEquals(listOf("AA", "BB", "CC"), byteGroup!!.bytes)
+        assertEquals(0..2, byteGroup.definition.indexes)
+        assertEquals(DEFAULT_REPRESENTATION, byteGroup.definition.representation)
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/scripting/ScriptHost.kt
+++ b/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/scripting/ScriptHost.kt
@@ -56,6 +56,7 @@ class ScriptHost(
                     // Add the pre-release compiler options enabled in the app `build.gradle.kts`
                     // to ensure compatibility with the app's compilation settings
                     compilerOptions.append(
+                        "-Xexplicit-backing-fields", // Workaround for IDEA "syntax error"
                         "-Xcontext-parameters",
                     )
                 }

--- a/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/MainPane.kt
+++ b/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/MainPane.kt
@@ -40,6 +40,7 @@ fun MainPane(
     selectedByteItem: ByteItem? = null,
     onByteItemSelected: (ByteItem?) -> Unit = {},
     onInputTypeChanged: (InputType) -> Unit = {},
+    onAddDefinition: (IntRange) -> Unit= {},
 ) {
     Column(
         modifier = modifier.fillMaxSize(),
@@ -97,6 +98,7 @@ fun MainPane(
             onByteItemClicked = {
                 onByteItemSelected(if (selectedByteItem != it) it else null)
             },
+            onAddDefinition = onAddDefinition,
         )
     }
 }

--- a/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/TabContent.kt
+++ b/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/TabContent.kt
@@ -104,6 +104,13 @@ fun TabContent(
                 onInputTypeChanged = { inputType ->
                     onCurrentTabEvent(CurrentTabEvent.ChangeInputTypeEvent(inputType))
                 },
+                onAddDefinition = { indexes ->
+                    val definition = ByteGroupDefinition(
+                        indexes = indexes,
+                        representation = noDefinitionRepresentation,
+                    )
+                    onCurrentTabEvent(CurrentTabEvent.AddDefinitionEvent(definition))
+                },
                 modifier = Modifier.padding(16.dp),
             )
         },

--- a/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/TabContent.kt
+++ b/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/TabContent.kt
@@ -54,10 +54,10 @@ fun TabContent(
     }
 
     // As ByteItem.SingleByte do not have a definition, we use the same representation for all of them.
-    // The same representation will be used for full-payload representation, when there is no definition.
+    // The same representation will be used for full-payload representation when there is no definition.
     // (note that it is possible to create a ByteGroup with a single byte)
     var noDefinitionRepresentation by remember {
-        mutableStateOf(Representation(DataRenderer.Off))
+        mutableStateOf(Representation(DataRenderer.Hexadecimal))
     }
 
     val fullPayload: ByteGroup? = remember(inputData, definitions, noDefinitionRepresentation) {

--- a/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/TabContent.kt
+++ b/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/TabContent.kt
@@ -152,13 +152,15 @@ fun TabContent(
             }
         },
         tools = (selectedByteItem ?: fullPayload).optionalSlot { renderedByteItem ->
+            val useDefinitionRepresentation = renderedByteItem is ByteGroup
+                && renderedByteItem in byteItems
             ByteItemRender(
                 byteItem = renderedByteItem,
-                representation = if (renderedByteItem is ByteGroup) {
+                representation = if (useDefinitionRepresentation) {
                     renderedByteItem.definition.representation
                 } else noDefinitionRepresentation,
                 onRepresentationChanged = { representation ->
-                    if (renderedByteItem is ByteGroup && renderedByteItem != fullPayload) {
+                    if (useDefinitionRepresentation) {
                         val currentDefinition = renderedByteItem.definition
                         if (representation != currentDefinition.representation) {
                             val updatedDefinition = currentDefinition.copy(representation = representation)

--- a/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/components/data/HexDisplay.kt
+++ b/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/components/data/HexDisplay.kt
@@ -9,6 +9,7 @@ package fr.nicopico.petitboutiste.ui.components.data
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -22,9 +23,15 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -35,8 +42,10 @@ import androidx.compose.ui.unit.sp
 import fr.nicopico.petitboutiste.models.definition.ByteGroup
 import fr.nicopico.petitboutiste.models.definition.ByteItem
 import fr.nicopico.petitboutiste.models.definition.SingleByte
+import fr.nicopico.petitboutiste.models.definition.contains
 import fr.nicopico.petitboutiste.models.definition.name
 import fr.nicopico.petitboutiste.models.definition.size
+import fr.nicopico.petitboutiste.models.definition.toByteGroup
 import fr.nicopico.petitboutiste.ui.components.foundation.modifier.clickableWithIndication
 import fr.nicopico.petitboutiste.ui.theme.AppTheme
 import fr.nicopico.petitboutiste.ui.theme.colors
@@ -67,6 +76,40 @@ fun HexDisplay(
             // Add grid state to track scrolling
             val gridState = rememberLazyGridState()
 
+            var dragAnchorIndex by remember { mutableStateOf<Int?>(null) }
+
+            fun itemIndexAt(offset: Offset): Int? {
+                return gridState.layoutInfo.visibleItemsInfo
+                    .firstOrNull { itemInfo ->
+                        offset.x >= itemInfo.offset.x &&
+                            offset.x < itemInfo.offset.x + itemInfo.size.width &&
+                            offset.y >= itemInfo.offset.y &&
+                            offset.y < itemInfo.offset.y + itemInfo.size.height
+                    }
+                    ?.index
+            }
+
+            fun updateDragSelection(targetIndex: Int?) {
+                val anchorIndex = dragAnchorIndex
+                if (anchorIndex == null || targetIndex == null) return
+
+                val range = if (anchorIndex <= targetIndex) {
+                    anchorIndex..targetIndex
+                } else {
+                    targetIndex..anchorIndex
+                }
+
+                val selectedItems = byteItems.slice(range)
+
+                // TODO Ugly hack
+                if (selectedItems.all { it is SingleByte }) {
+                    onByteItemClicked(selectedItems.toByteGroup()!!)
+                } else if (selectedByteItem != null) {
+                    // Unselect
+                    onByteItemClicked(selectedByteItem)
+                }
+            }
+
             VerticallyScrollableContainer(
                 scrollState = gridState as ScrollableState,
                 style = AppTheme.current.styles.scrollbarStyle,
@@ -76,7 +119,31 @@ fun HexDisplay(
                     state = gridState,
                     horizontalArrangement = Arrangement.Start,
                     verticalArrangement = Arrangement.Top,
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .pointerInput(byteItems) {
+                            detectDragGestures(
+                                onDragStart = { offset ->
+                                    val index = itemIndexAt(offset)
+                                    if (index != null && byteItems[index] is SingleByte) {
+                                        dragAnchorIndex = index
+                                        updateDragSelection(index)
+                                    } else {
+                                        dragAnchorIndex = null
+                                    }
+                                },
+                                onDrag = { change, _ ->
+                                    change.consume()
+                                    updateDragSelection(itemIndexAt(change.position))
+                                },
+                                onDragEnd = {
+                                    dragAnchorIndex = null
+                                },
+                                onDragCancel = {
+                                    dragAnchorIndex = null
+                                },
+                            )
+                        }
                 ) {
                     items(
                         items = byteItems,
@@ -98,7 +165,9 @@ fun HexDisplay(
                             item = item,
                             modifier = Modifier
                                 .padding(4.dp)
-                                .clickableWithIndication { onByteItemClicked(item) }
+                                .clickableWithIndication {
+                                    onByteItemClicked(item)
+                                }
                                 .let {
                                     when (item) {
                                         is SingleByte -> it
@@ -114,7 +183,7 @@ fun HexDisplay(
                                     }
                                 }
                                 .let {
-                                    if (item == selectedByteItem) {
+                                    if (selectedByteItem != null && item in selectedByteItem) {
                                         it.background(AppTheme.current.colors.accentContainer)
                                     } else it
                                 }

--- a/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/components/data/HexDisplay.kt
+++ b/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/components/data/HexDisplay.kt
@@ -101,13 +101,10 @@ fun HexDisplay(
 
                 val selectedItems = byteItems.slice(range)
 
-                // TODO Ugly hack
-                if (selectedItems.all { it is SingleByte }) {
-                    onByteItemClicked(selectedItems.toByteGroup()!!)
-                } else if (selectedByteItem != null) {
-                    // Unselect
-                    onByteItemClicked(selectedByteItem)
-                }
+                selectedItems.toByteGroup()
+                    ?.let { tempByteGroup ->
+                        onByteItemClicked(tempByteGroup)
+                    }
             }
 
             VerticallyScrollableContainer(

--- a/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/components/data/HexDisplay.kt
+++ b/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/components/data/HexDisplay.kt
@@ -6,6 +6,8 @@
 
 package fr.nicopico.petitboutiste.ui.components.data
 
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.ScrollableState
@@ -51,6 +53,7 @@ import fr.nicopico.petitboutiste.ui.theme.AppTheme
 import fr.nicopico.petitboutiste.ui.theme.colors
 import fr.nicopico.petitboutiste.ui.theme.styles
 import fr.nicopico.petitboutiste.ui.theme.typography
+import fr.nicopico.petitboutiste.utils.compose.Slot
 import fr.nicopico.petitboutiste.utils.compose.preview.ByteItemsParameterProvider
 import fr.nicopico.petitboutiste.utils.compose.preview.WrapForPreviewDesktop
 import org.jetbrains.jewel.ui.component.Text
@@ -64,8 +67,13 @@ fun HexDisplay(
     modifier: Modifier = Modifier,
     selectedByteItem: ByteItem? = null,
     onByteItemClicked: (ByteItem) -> Unit = {},
+    onAddDefinition: (IntRange) -> Unit= {},
 ) {
     if (byteItems.isNotEmpty()) {
+        val isTemporarySelection = remember(byteItems, selectedByteItem) {
+            selectedByteItem != null && selectedByteItem !in byteItems
+        }
+
         BoxWithConstraints(modifier) {
             val availableWidthPx = constraints.maxWidth
             val columnWidthPx = with(LocalDensity.current) {
@@ -158,34 +166,42 @@ fun HexDisplay(
                             }
                         },
                     ) { item ->
-                        ByteItemView(
-                            item = item,
-                            modifier = Modifier
-                                .padding(4.dp)
-                                .clickableWithIndication {
-                                    onByteItemClicked(item)
-                                }
-                                .let {
-                                    when (item) {
-                                        is SingleByte -> it
-                                        is ByteGroup if item.incomplete -> it.border(
-                                            1.dp,
-                                            AppTheme.current.colors.errorColor
-                                        )
+                        val inSelection = selectedByteItem != null && item in selectedByteItem
 
-                                        is ByteGroup -> it.border(
-                                            1.dp,
-                                            AppTheme.current.colors.accentColor
-                                        )
+                        TemporaryByteGroupContextMenu(
+                            selectedByteItem,
+                            enabled = inSelection && isTemporarySelection,
+                            onAddDefinition = onAddDefinition,
+                        ) {
+                            ByteItemView(
+                                item = item,
+                                modifier = Modifier
+                                    .padding(4.dp)
+                                    .clickableWithIndication {
+                                        onByteItemClicked(item)
                                     }
-                                }
-                                .let {
-                                    if (selectedByteItem != null && item in selectedByteItem) {
-                                        it.background(AppTheme.current.colors.accentContainer)
-                                    } else it
-                                }
-                                .padding(4.dp)
-                        )
+                                    .let {
+                                        when (item) {
+                                            is SingleByte -> it
+                                            is ByteGroup if item.incomplete -> it.border(
+                                                1.dp,
+                                                AppTheme.current.colors.errorColor
+                                            )
+
+                                            is ByteGroup -> it.border(
+                                                1.dp,
+                                                AppTheme.current.colors.accentColor
+                                            )
+                                        }
+                                    }
+                                    .let {
+                                        if (selectedByteItem != null && item in selectedByteItem) {
+                                            it.background(AppTheme.current.colors.accentContainer)
+                                        } else it
+                                    }
+                                    .padding(4.dp)
+                            )
+                        }
                     }
                 }
             }
@@ -231,6 +247,29 @@ private fun ByteItemView(
             overflow = TextOverflow.Ellipsis,
         )
     }
+}
+
+@Composable
+private fun TemporaryByteGroupContextMenu(
+    selectedByteItem: ByteItem?,
+    enabled: Boolean,
+    onAddDefinition: (IntRange) -> Unit,
+    content: Slot,
+) {
+    if (selectedByteItem != null && enabled) {
+        ContextMenuArea(
+            items = {
+                listOf(
+                    ContextMenuItem("Create a new definition") {
+                        onAddDefinition(
+                            selectedByteItem.firstIndex..selectedByteItem.lastIndex
+                        )
+                    }
+                )
+            },
+            content = content,
+        )
+    } else content()
 }
 
 @Preview

--- a/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/components/data/HexDisplay.kt
+++ b/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/components/data/HexDisplay.kt
@@ -94,8 +94,8 @@ fun HexDisplay(
                             }
                         },
                     ) { item ->
-                        Column(
-                            horizontalAlignment = Alignment.Start,
+                        ByteItemView(
+                            item = item,
                             modifier = Modifier
                                 .padding(4.dp)
                                 .clickableWithIndication { onByteItemClicked(item) }
@@ -119,41 +119,52 @@ fun HexDisplay(
                                     } else it
                                 }
                                 .padding(4.dp)
-                        ) {
-                            Text(
-                                text = item.toString(),
-                                style = AppTheme.current.typography.data,
-                            )
-
-                            val index = if (item.firstIndex != item.lastIndex) {
-                                "${item.firstIndex}..${item.lastIndex}"
-                            } else item.firstIndex.toString()
-                            Text(
-                                text = index,
-                                style = TextStyle(
-                                    fontFamily = FontFamily.Monospace,
-                                    fontSize = 9.sp,
-                                    color = Color.Gray
-                                )
-                            )
-
-                            Text(
-                                text = item.name.orEmpty(),
-                                style = TextStyle(
-                                    fontFamily = FontFamily.Monospace,
-                                    fontSize = 8.sp,
-                                    color = AppTheme.current.colors.accentColor,
-                                ),
-                                softWrap = false,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
+                        )
                     }
                 }
             }
         }
     } else Box(modifier)
+}
+
+@Composable
+private fun ByteItemView(
+    item: ByteItem,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.Start,
+        modifier = modifier
+    ) {
+        Text(
+            text = item.toString(),
+            style = AppTheme.current.typography.data,
+        )
+
+        val index = if (item.firstIndex != item.lastIndex) {
+            "${item.firstIndex}..${item.lastIndex}"
+        } else item.firstIndex.toString()
+        Text(
+            text = index,
+            style = TextStyle(
+                fontFamily = FontFamily.Monospace,
+                fontSize = 9.sp,
+                color = Color.Gray
+            )
+        )
+
+        Text(
+            text = item.name.orEmpty(),
+            style = TextStyle(
+                fontFamily = FontFamily.Monospace,
+                fontSize = 8.sp,
+                color = AppTheme.current.colors.accentColor,
+            ),
+            softWrap = false,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
 }
 
 @Preview

--- a/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/components/definition/ByteGroupDefinitions.kt
+++ b/composeApp/src/desktopMain/kotlin/fr/nicopico/petitboutiste/ui/components/definition/ByteGroupDefinitions.kt
@@ -148,7 +148,10 @@ fun ByteGroupDefinitions(
             verticalArrangement = Arrangement.spacedBy(8.dp),
             state = lazyListState,
         ) {
-            items(definitions) { definition ->
+            items(
+                items = definitions,
+                key = { it.id },
+            ) { definition ->
                 val byteGroup = byteItems.firstOrNull {
                     it is ByteGroup && it.definition == definition
                 } as? ByteGroup

--- a/composeApp/stability/composeApp.stability
+++ b/composeApp/stability/composeApp.stability
@@ -43,7 +43,7 @@ public fun fr.nicopico.petitboutiste.ui.AppShortcuts(content: @[Composable] andr
     - content: STABLE (composable function type)
 
 @Composable
-public fun fr.nicopico.petitboutiste.ui.MainPane(inputData: fr.nicopico.petitboutiste.models.data.DataString, byteItems: kotlin.collections.List<fr.nicopico.petitboutiste.models.definition.ByteItem>, onInputDataChanged: kotlin.Function1<fr.nicopico.petitboutiste.models.data.DataString, kotlin.Unit>, modifier: androidx.compose.ui.Modifier, selectedByteItem: fr.nicopico.petitboutiste.models.definition.ByteItem?, onByteItemSelected: kotlin.Function1<fr.nicopico.petitboutiste.models.definition.ByteItem?, kotlin.Unit>, onInputTypeChanged: kotlin.Function1<fr.nicopico.petitboutiste.state.InputType, kotlin.Unit>): kotlin.Unit
+public fun fr.nicopico.petitboutiste.ui.MainPane(inputData: fr.nicopico.petitboutiste.models.data.DataString, byteItems: kotlin.collections.List<fr.nicopico.petitboutiste.models.definition.ByteItem>, onInputDataChanged: kotlin.Function1<fr.nicopico.petitboutiste.models.data.DataString, kotlin.Unit>, modifier: androidx.compose.ui.Modifier, selectedByteItem: fr.nicopico.petitboutiste.models.definition.ByteItem?, onByteItemSelected: kotlin.Function1<fr.nicopico.petitboutiste.models.definition.ByteItem?, kotlin.Unit>, onInputTypeChanged: kotlin.Function1<fr.nicopico.petitboutiste.state.InputType, kotlin.Unit>, onAddDefinition: kotlin.Function1<kotlin.ranges.IntRange, kotlin.Unit>): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -54,6 +54,7 @@ public fun fr.nicopico.petitboutiste.ui.MainPane(inputData: fr.nicopico.petitbou
     - selectedByteItem: STABLE (class with no mutable properties)
     - onByteItemSelected: STABLE (function type)
     - onInputTypeChanged: STABLE (function type)
+    - onAddDefinition: STABLE (function type)
 
 @Composable
 public fun fr.nicopico.petitboutiste.ui.TabContent(inputData: fr.nicopico.petitboutiste.models.data.DataString, definitions: kotlin.collections.List<fr.nicopico.petitboutiste.models.definition.ByteGroupDefinition>, byteItems: kotlin.collections.List<fr.nicopico.petitboutiste.models.definition.ByteItem>, scratchpad: kotlin.String): kotlin.Unit
@@ -66,7 +67,15 @@ public fun fr.nicopico.petitboutiste.ui.TabContent(inputData: fr.nicopico.petitb
     - scratchpad: STABLE (String is immutable)
 
 @Composable
-public fun fr.nicopico.petitboutiste.ui.components.data.HexDisplay(byteItems: kotlin.collections.List<fr.nicopico.petitboutiste.models.definition.ByteItem>, modifier: androidx.compose.ui.Modifier, selectedByteItem: fr.nicopico.petitboutiste.models.definition.ByteItem?, onByteItemClicked: kotlin.Function1<fr.nicopico.petitboutiste.models.definition.ByteItem, kotlin.Unit>): kotlin.Unit
+private fun fr.nicopico.petitboutiste.ui.components.data.ByteItemView(item: fr.nicopico.petitboutiste.models.definition.ByteItem, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - item: STABLE (class with no mutable properties)
+    - modifier: STABLE (marked @Stable or @Immutable)
+
+@Composable
+public fun fr.nicopico.petitboutiste.ui.components.data.HexDisplay(byteItems: kotlin.collections.List<fr.nicopico.petitboutiste.models.definition.ByteItem>, modifier: androidx.compose.ui.Modifier, selectedByteItem: fr.nicopico.petitboutiste.models.definition.ByteItem?, onByteItemClicked: kotlin.Function1<fr.nicopico.petitboutiste.models.definition.ByteItem, kotlin.Unit>, onAddDefinition: kotlin.Function1<kotlin.ranges.IntRange, kotlin.Unit>): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -74,6 +83,17 @@ public fun fr.nicopico.petitboutiste.ui.components.data.HexDisplay(byteItems: ko
     - modifier: STABLE (marked @Stable or @Immutable)
     - selectedByteItem: STABLE (class with no mutable properties)
     - onByteItemClicked: STABLE (function type)
+    - onAddDefinition: STABLE (function type)
+
+@Composable
+private fun fr.nicopico.petitboutiste.ui.components.data.TemporaryByteGroupContextMenu(selectedByteItem: fr.nicopico.petitboutiste.models.definition.ByteItem?, enabled: kotlin.Boolean, onAddDefinition: kotlin.Function1<kotlin.ranges.IntRange, kotlin.Unit>, content: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - selectedByteItem: STABLE (class with no mutable properties)
+    - enabled: STABLE (primitive type)
+    - onAddDefinition: STABLE (function type)
+    - content: STABLE (composable function type)
 
 @Composable
 public fun fr.nicopico.petitboutiste.ui.components.data.input.DataInput(value: T of fr.nicopico.petitboutiste.ui.components.data.input.DataInput, adapter: fr.nicopico.petitboutiste.ui.components.data.input.DataInputAdapter<T of fr.nicopico.petitboutiste.ui.components.data.input.DataInput>, onValueChange: kotlin.Function1<fr.nicopico.petitboutiste.models.data.DataString, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit

--- a/detekt-baseline-composeApp-main.xml
+++ b/detekt-baseline-composeApp-main.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>CyclomaticComplexMethod:HexDisplay.kt$@Composable fun HexDisplay( byteItems: List&lt;ByteItem&gt;, modifier: Modifier = Modifier, selectedByteItem: ByteItem? = null, onByteItemClicked: (ByteItem) -&gt; Unit = {}, onAddDefinition: (IntRange) -&gt; Unit= {}, )</ID>
     <ID>InjectDispatcher:ArgumentInput.kt$Default</ID>
     <ID>InjectDispatcher:FileDialog.desktop.kt$DefaultFileDialog$IO</ID>
     <ID>InjectDispatcher:ScriptHost.kt$ScriptHost$IO</ID>
@@ -9,7 +10,9 @@
     <ID>LongMethod:ArgumentInput.kt$@OptIn(FlowPreview::class) @Composable fun ArgumentInput( argument: DataRenderer.Argument, userValue: ArgValue?, onValueChanged: (ArgValue?) -&gt; Unit, completeArguments: ArgumentValues, modifier: Modifier = Modifier, onError: (String) -&gt; Unit = {}, keyboardOptions: KeyboardOptions = KeyboardOptions.Default, onKeyboardAction: (() -&gt; Unit)? = null, )</ID>
     <ID>LongMethod:ByteGroupDefinitionItem.kt$@Composable fun ByteGroupDefinitionItem( definition: ByteGroupDefinition, onToggleDisplayForm: (Boolean) -&gt; Unit, onDelete: () -&gt; Unit, modifier: Modifier = Modifier, isSelected: Boolean = false, byteGroup: ByteGroup? = null, errorMessage: String? = null, form: Slot? = null, displayForm: Boolean = false, )</ID>
     <ID>LongMethod:ByteItemRender.kt$@Composable fun ByteItemRender( byteItem: ByteItem, representation: Representation, onRepresentationChanged: (Representation) -&gt; Unit, modifier: Modifier = Modifier, )</ID>
+    <ID>LongMethod:HexDisplay.kt$@Composable fun HexDisplay( byteItems: List&lt;ByteItem&gt;, modifier: Modifier = Modifier, selectedByteItem: ByteItem? = null, onByteItemClicked: (ByteItem) -&gt; Unit = {}, onAddDefinition: (IntRange) -&gt; Unit= {}, )</ID>
     <ID>LongMethod:Reducer.kt$Reducer$suspend operator fun invoke(state: AppState, event: AppEvent): AppState</ID>
     <ID>LongMethod:TabContent.kt$@Composable fun TabContent( inputData: DataString, definitions: List&lt;ByteGroupDefinition&gt;, byteItems: List&lt;ByteItem&gt;, scratchpad: String = "", )</ID>
+    <ID>ReturnCount:ByteItemListExt.kt$fun List&lt;ByteItem&gt;.toByteGroup( representation: Representation = DEFAULT_REPRESENTATION, ): ByteGroup?</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/detekt-baseline-composeApp.xml
+++ b/detekt-baseline-composeApp.xml
@@ -2,10 +2,13 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>CyclomaticComplexMethod:HexDisplay.kt$@Composable fun HexDisplay( byteItems: List&lt;ByteItem&gt;, modifier: Modifier = Modifier, selectedByteItem: ByteItem? = null, onByteItemClicked: (ByteItem) -&gt; Unit = {}, onAddDefinition: (IntRange) -&gt; Unit= {}, )</ID>
     <ID>LongMethod:ArgumentInput.kt$@OptIn(FlowPreview::class) @Composable fun ArgumentInput( argument: DataRenderer.Argument, userValue: ArgValue?, onValueChanged: (ArgValue?) -&gt; Unit, completeArguments: ArgumentValues, modifier: Modifier = Modifier, onError: (String) -&gt; Unit = {}, keyboardOptions: KeyboardOptions = KeyboardOptions.Default, onKeyboardAction: (() -&gt; Unit)? = null, )</ID>
     <ID>LongMethod:ByteGroupDefinitionItem.kt$@Composable fun ByteGroupDefinitionItem( definition: ByteGroupDefinition, onToggleDisplayForm: (Boolean) -&gt; Unit, onDelete: () -&gt; Unit, modifier: Modifier = Modifier, isSelected: Boolean = false, byteGroup: ByteGroup? = null, errorMessage: String? = null, form: Slot? = null, displayForm: Boolean = false, )</ID>
     <ID>LongMethod:ByteItemRender.kt$@Composable fun ByteItemRender( byteItem: ByteItem, representation: Representation, onRepresentationChanged: (Representation) -&gt; Unit, modifier: Modifier = Modifier, )</ID>
+    <ID>LongMethod:HexDisplay.kt$@Composable fun HexDisplay( byteItems: List&lt;ByteItem&gt;, modifier: Modifier = Modifier, selectedByteItem: ByteItem? = null, onByteItemClicked: (ByteItem) -&gt; Unit = {}, onAddDefinition: (IntRange) -&gt; Unit= {}, )</ID>
     <ID>LongMethod:Reducer.kt$Reducer$suspend operator fun invoke(state: AppState, event: AppEvent): AppState</ID>
     <ID>LongMethod:TabContent.kt$@Composable fun TabContent( inputData: DataString, definitions: List&lt;ByteGroupDefinition&gt;, byteItems: List&lt;ByteItem&gt;, scratchpad: String = "", )</ID>
+    <ID>ReturnCount:ByteItemListExt.kt$fun List&lt;ByteItem&gt;.toByteGroup( representation: Representation = DEFAULT_REPRESENTATION, ): ByteGroup?</ID>
   </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
### Summary of Changes
- Implemented a feature to create new definitions based on mouse selection.
- Added functionality for mouse selection in data input.
- Updated the default "no-definition" representation to use hexadecimal format.
- Refactored the `HexDisplay` component for cleaner structure and maintainability.
- Performed general code clean-up and addressed an IDE compilation error workaround.


https://github.com/user-attachments/assets/04b36f4f-6bfd-4f37-a103-8cb030923d58